### PR TITLE
fix: clean main branch for Render deployment

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -4,7 +4,7 @@ services:
     name: pandegooseium
     env: node
     plan: free
-    branch: fix/final-render-deployment
+    branch: main
     buildCommand: npm install --legacy-peer-deps && npm run build
     startCommand: npm run start
     healthCheckPath: /

--- a/src/app/api/question/[case]/route.ts
+++ b/src/app/api/question/[case]/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { promises as fs } from 'fs';
 import path from 'path';
-import { levenshtein } from '@/utils/levenshtein';
+import { levenshtein } from '../../../../utils/levenshtein';
 
 async function loadQuestions() {
   const filePath = path.join(process.cwd(), 'data', 'questions.json');


### PR DESCRIPTION
- Use relative import path for levenshtein utility (guaranteed to work)
- Set render.yaml to deploy from main branch
- Remove temporary debug files
- Ensure build works consistently